### PR TITLE
fix: Error: opam package "melange-jest.dev" requires npm package "jes…

### DIFF
--- a/melange-jest.opam
+++ b/melange-jest.opam
@@ -33,8 +33,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/melange-community/melange-jest.git"
 depexts: [
-  ["jest"] {npm-version = "^27.0.0"}
-  ["jest-environment-jsdom"] {npm-version = "^27.0.0"}
+  ["jest"] {npm-version = "^29.0.0"}
+  ["jest-environment-jsdom"] {npm-version = "^29.0.0"}
   ["@testing-library/jest-dom"] {npm-version = "^5.10.0"}
 ]
 

--- a/melange-jest.opam.template
+++ b/melange-jest.opam.template
@@ -1,6 +1,6 @@
 depexts: [
-  ["jest"] {npm-version = "^27.0.0"}
-  ["jest-environment-jsdom"] {npm-version = "^27.0.0"}
+  ["jest"] {npm-version = "^29.0.0"}
+  ["jest-environment-jsdom"] {npm-version = "^29.0.0"}
   ["@testing-library/jest-dom"] {npm-version = "^5.10.0"}
 ]
 


### PR DESCRIPTION
Fixes:

Error: opam package "melange-jest.dev" requires npm package "jest" with constraint "^27.0.0", but the version installed found in file "/node_modules/jest/package.json" is "29.7.0"